### PR TITLE
Fix: Unused variable warning

### DIFF
--- a/src/gain_analysis.c
+++ b/src/gain_analysis.c
@@ -80,7 +80,6 @@ static long     totsamp;
 static double   lsum;
 static double   rsum;
 static int      freqindex;
-static int      first;
 static int		chap_void;	// if == 0 gain_analyze_samples as been called
 static Uint32_t A [ANALYZE_SIZE];	// chapter
 static Uint32_t B [ANALYZE_SIZE];	// title
@@ -422,17 +421,17 @@ gain_get_title ( void )
 {
 	Float_t  retval;
 	int    i;
-	
+
 	if (chap_void == 0)
 		gain_get_chapter();
-	
+
 	retval = analyzeResult ( B, ANALYZE_SIZE );
-	
+
 	for ( i = 0; i < ANALYZE_SIZE; i++ ) {
 		C[i] += B[i];
 		B[i]  = 0;
 	}
-	
+
 	return retval;
 }
 


### PR DESCRIPTION
This PR fixes the unused variable warning caused by the `first` global in gain_analysis.c.

This was caught in the [CI testing cycle for libAudio macOS builds](https://github.com/dragonCodecs/libAudio/actions/runs/6029542457/job/16359327417#step:11:22)